### PR TITLE
Adds mergeable and dependabot configs

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -1,0 +1,15 @@
+# To get started with Dependabot version updates, you'll need to specify which
+# package ecosystems to update and where the package manifests are located.
+# Please see the documentation for all configuration options:
+# https://help.github.com/github/administering-a-repository/configuration-options-for-dependency-updates
+
+version: 2
+updates:
+  - package-ecosystem: "npm" # See documentation for possible values
+    directory: "/" # Location of package manifests
+    schedule:
+      interval: "monthly"
+  - package-ecosystem: "nuget"
+    directory: "/build"
+    schedule:
+      interval: "monthly"

--- a/.github/mergeable.yaml
+++ b/.github/mergeable.yaml
@@ -1,0 +1,12 @@
+version: 2
+mergeable:
+  - when: pull_request.*, issues.*
+    validate:
+      - do: milestone
+        no_empty:
+          enabled: true
+          message: 'A milestone must be assigned to this pull request'
+      - do: label
+        no_empty:
+          enabled: true
+          message: 'A label must be assigned to this pull request'


### PR DESCRIPTION
- mergeable will help with enforcing we have at least 1 label and a milestone for each PR. This is assumed by the build and it will prevent release automation issues.
- dependabot will help keep dependencies up-to-date and be aware of any security related issues from dependencies.