### PR TITLE
Updated to allow empty total amount and down payment with default value

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,11 @@
 {
-  "name": "nvq-loan-calculator",
+  "name": "@nvisionative/nvq-loan-calculator",
   "version": "1.0.0-beta0001",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
-      "name": "nvq-loan-calculator",
+      "name": "@nvisionative/nvq-loan-calculator",
       "version": "1.0.0-beta0001",
       "license": "MIT",
       "devDependencies": {

--- a/src/components/nvq-loan-calculator/nvq-loan-calculator.tsx
+++ b/src/components/nvq-loan-calculator/nvq-loan-calculator.tsx
@@ -71,6 +71,11 @@ export class NvqLoanCalculator {
   }
 
   private getValidatedNumber(target: HTMLInputElement, digits: number, defaultValue: number = 0): number {
+    if (target.value === '') {
+      target.dataset.lastValidValue = defaultValue.toString();
+      return undefined;
+    }
+
     if (target.validity.valid) {
       const value = parseFloat(target.value);
       const roundedValue = this.roundTo(value, digits);
@@ -115,6 +120,10 @@ export class NvqLoanCalculator {
   }
 
   private calculatePayment() {
+    if (isNaN(this.downPayment)) {
+      this.downPayment = 0;
+    }
+
     // Assuming monthly compounding.
     const monthlyInterestRate = this.interestRate / 100 / 12;
     if (this.amortizationYears === undefined){
@@ -176,8 +185,7 @@ export class NvqLoanCalculator {
                 min={0}
                 max={this.totalAmount}
                 step={0.01}
-                required
-                value={this.downPayment}
+                value={this.downPayment > 0 ? this.downPayment : ''}
                 onKeyDown={e => this.onlyAllowNumbers(e)}
                 onInput={e => this.downPayment = this.getValidatedNumber(e.target as HTMLInputElement, 2)}
                 onBlur={e => this.displayErrorIfAny(e.target as HTMLInputElement)}


### PR DESCRIPTION
* `Total Amount` now allows empty value, but that will kick in validation appropriately, as this is still a required field.
* `Down Payment` now allows empty value, but behind the veil it uses `0` as the value for monthly payment calculation